### PR TITLE
[Fix] Trailing spaces are not error on lines containing only spaces

### DIFF
--- a/syntax/coffee.vim
+++ b/syntax/coffee.vim
@@ -136,7 +136,7 @@ syntax region coffeeParens start=/(/ end=/)/ contains=TOP
 
 " Displays an error for trailing whitespace
 if !exists("coffee_no_trailing_space_error")
-  syntax match coffeeSpaceError /\s\+$/ display
+  syntax match coffeeSpaceError /(?<=\S)\s\+$/ display
   highlight default link coffeeSpaceError Error
 endif
 


### PR DESCRIPTION
On “empty” lines (containing only spaces, when autoindent is on), spaces are treated like an error. That’s annoying, this commit fix that.
