### PR TITLE
Fix for #28

### DIFF
--- a/ftplugin/coffee.vim
+++ b/ftplugin/coffee.vim
@@ -13,7 +13,6 @@ setlocal formatoptions-=t formatoptions+=croql
 setlocal comments=:#
 setlocal commentstring=#\ %s
 
-setlocal makeprg=coffee\ -c\ $*
 setlocal errorformat=Error:\ In\ %f\\,\ %m\ on\ line\ %l,
                     \Error:\ In\ %f\\,\ Parse\ error\ on\ line\ %l:\ %m,
                     \SyntaxError:\ In\ %f\\,\ %m,
@@ -30,14 +29,20 @@ if !exists("coffee_make_options")
   let coffee_make_options = ""
 endif
 
-function! s:CoffeeMake(bang, args)
-  exec ('make' . a:bang) g:coffee_make_options a:args fnameescape(expand('%'))
+" Function that sets the correct makeprg.
+function! s:SetMakePrg()
+  let &l:makeprg = "coffee -c " . g:coffee_make_options . ' $* ' . fnameescape(expand('%'))
 endfunction
+
+" Set makeprg.
+call s:SetMakePrg()
+" Reset makeprg on rename.
+autocmd BufFilePost,BufWritePost,FileWritePost <buffer> call s:SetMakePrg()
 
 " Compile some CoffeeScript.
 command! -range=% CoffeeCompile <line1>,<line2>:w !coffee -scb
 " Compile the current file.
-command! -bang -bar -nargs=* CoffeeMake call s:CoffeeMake(<q-bang>, <q-args>)
+command! -bang -bar -nargs=* CoffeeMake make<bang> <args>
 " Run the selected text or the entire file and show output on vim command line
 command! -range=% CoffeeRun <line1>,<line2>:w !coffee -s
 


### PR DESCRIPTION
> This is basically a hack. Since there is no other way to escape special
> characters in filenames except using `fnameescape`, we have to
> specifically set `makeprg` according to the filename. And in order to
> catch all the rename, new file, open file cases, an autocmd is
> introduced. Note that backward compatibility is preserved: command
> `CoffeeMake` still exists and should do whatever what it was doing before.
> But function `CoffeeMake` has been removed. Also the built-in `make` does
> not work the same way as `CoffeeMake`, the difference is that `CoffeeMake`
> is chainable while the built-in make is not.

This commit fixes #28. Both the built-in `make` and `CoffeeMake` work now. I preserved `CoffeeMake` for backward compatibility. Note the only difference between `make` and `CoffeeMake` is that `CoffeeMake` can be chained to other command while `make` cannot(because of `$*`). But still, I think the built-in `make` is good enough to replace `CoffeeMake`. I'll leave it to you to decide whether to keep `CoffeeMake` or not.
