### PR TITLE
Add docs in Vim help format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .*.sw[a-z]
 .*.un~
+doc/tags
+

--- a/doc/coffee-script.txt
+++ b/doc/coffee-script.txt
@@ -1,0 +1,114 @@
+*coffee-script.txt*	Plugin for editing, compiling and running CoffeeScript
+
+=============================================================================
+Author:  Mick Koch <kchmck@gmail.com>		*coffee-script-author*
+License: WTFPL (see |coffee-script-license|)
+
+=============================================================================
+
+CONTENTS					*coffee-script-contents*
+
+|coffee-script-introduction|		Introduction and Feature Summary
+|coffee-script-commands|		Commands
+|coffee-script-settings|		Settings
+
+{Vi does not have any of this}
+
+=============================================================================
+
+INTRODUCTION					*coffee-script*
+						*coffee-script-introduction*
+
+This plugin provides facilities for editing CoffeeScript, including syntax
+highlighting, indenting and compilation.  Also included is syntax support for
+Eco templates, and handling of {text/coffeescript} in HTML.
+
+
+COMMANDS					*coffee-script-commands*
+
+						*:CoffeeMake*
+:CoffeeMake {opts}	Calls |:make!|, with 'makeprg' being "coffee -c" plus
+			any additional {opts} given.  Opens the |quickfix|
+			window if there are any errors and jumps to the first
+			error.  You may set |g:coffee_make_options| to specify
+			default command-line options that will always be
+			passed.  By default, all compiler output is shown --
+			running with |:silent| will hide this.
+
+						*:CoffeeMake!*
+:CoffeeMake! {opts}	As with :CoffeeMake, but will not jump to the first
+			error.
+
+						*:CoffeeCompile*
+:[range]CoffeeCompile [vertical] [{win-size}]
+			Shows how the current file or [range] will be compiled
+			to JavaScript.  [vertical] (or vert) splits the
+			compile buffer vertically instead of horizontally, and
+			{win-size} sets the initial size of the buffer. It can
+			be closed quickly with the "q" key.
+
+:CoffeeCompile {watch} [vertical] [{win-size}]
+			The watch mode of :CoffeeCompile emulates the "Try
+			CoffeeScript" live preview on the CoffeeScript web
+			site -- after making changes to the source file,
+			exiting insert mode will cause the preview buffer to
+			update automatically.  {watch} should be given as
+			"watch" or "unwatch," where the latter will of course
+			stop the automatic updating. [vertical] is
+			recommended, and 'scrollbind' is useful.
+
+						*:CoffeeRun*
+:[range]CoffeeRun	Compiles the file or [range] and runs the resulting
+			JavaScript, displaying the output.
+
+
+SETTINGS					*coffee-script-settings*
+
+You can configure plugin behavior by setting global variables or syntax
+highlighting directives in your |vimrc|.
+
+Global Settings~
+
+You may set these in your |vimrc| as illustrated below.
+
+						*g:coffee_make_options*  >
+	let g:coffee_make_options='--bare'
+Always include the specified options when compiling with |:CoffeeCompile|.
+
+Syntax Highlighting~
+						*ft-coffee-script-syntax*
+Trailing whitespace is highlighted as an error by default. This can be
+disabled with:
+>
+	hi link coffeeSpaceError NONE
+
+Trailing semicolons are also considered an error (for help transitioning from
+JavaScript.) This can be disabled with:
+>
+	hi link coffeeSemicolonError NONE
+
+Reserved words like {function} and {var} are highlighted as an error in
+contexts disallowed by CoffeeScript. This can be disabled with:
+>
+	hi link coffeeReservedError NONE
+
+
+=============================================================================
+
+LICENSE							*coffee-script-license*
+
+		DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+			Version 2, December 2004
+
+     Copyright (C) 2010 to 2011 Mick Koch <kchmck@gmail.com>
+
+     Everyone is permitted to copy and distribute verbatim or modified
+     copies of this license document, and changing it is allowed as long
+     as the name is changed.
+
+		DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+       TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+      0. You just DO WHAT THE FUCK YOU WANT TO.
+
+ vim:tw=78:ts=8:ft=help:norl:


### PR DESCRIPTION
You may want to tweak it, but this should be a good start. Drives me batty when an otherwise good plugin makes me go fishing for its docs :-)
