### PR TITLE
Link string interpolation to Delimiter group

### DIFF
--- a/syntax/coffee.vim
+++ b/syntax/coffee.vim
@@ -156,7 +156,7 @@ hi def link coffeeEmbedDelim Delimiter
 
 syn region coffeeInterp matchgroup=coffeeInterpDelim start=/#{/ end=/}/ contained
 \                       contains=@coffeeAll
-hi def link coffeeInterpDelim PreProc
+hi def link coffeeInterpDelim Delimiter
 
 " A string escape sequence
 syn match coffeeEscape /\\\d\d\d\|\\x\x\{2\}\|\\u\x\{4\}\|\\./ contained display


### PR DESCRIPTION
The string interpolation operator was hurting my eyes, so I've linked it to the `Delimiter` group instead of `PreProc`. This is consistent with Vim's treatment of Ruby string interpolation.
