### PR TITLE
Support for coffeescript filter in haml

### DIFF
--- a/after/syntax/haml.vim
+++ b/after/syntax/haml.vim
@@ -1,2 +1,2 @@
 syn include @hamlCoffeeScript syntax/coffee.vim
-syn region  hamlCoffeescriptFilter matchgroup=hamlFilter start="^\z(\s*\):coffeescript\s*$" end="^\%(\z1 \| *$\)\@!" contains=@htmlCoffeeScript,hamlInterpolation keepend
+syn region  hamlCoffeescriptFilter matchgroup=hamlFilter start="^\z(\s*\):coffeescript\s*$" end="^\%(\z1 \| *$\)\@!" contains=@hamlCoffeeScript,hamlInterpolation keepend


### PR DESCRIPTION
Hi,

I added support for coffeescript filters in haml files.
I first added it to the vim-haml pluginin, but tpope pointed out that this should be the responsibility of this plugin.

see: https://github.com/tpope/vim-haml/pull/23

Want to pull this change?
