### PR TITLE
Add Javascript omni-completion

### DIFF
--- a/ftplugin/coffee.vim
+++ b/ftplugin/coffee.vim
@@ -12,6 +12,7 @@ let b:did_ftplugin = 1
 setlocal formatoptions-=t formatoptions+=croql
 setlocal comments=:#
 setlocal commentstring=#\ %s
+setlocal omnifunc=javascriptcomplete#CompleteJS
 
 " Extra options passed to CoffeeMake
 if !exists("coffee_make_options")


### PR DESCRIPTION
`<C-x><C-o>` is really helpful in some files. Javascript omnicompletion comes bundled with Vim (check out `:e $VIMRUNTIME/autoload/javascriptcomplete.vim`) and it's pretty useful even in Coffeescript files. Thought more people might find it useful to have more keywords available than `FIXME`, `TODO`, and `XXX`.
