### PR TITLE
Adding .coffeekup to ftdetect

### DIFF
--- a/ftdetect/coffee.vim
+++ b/ftdetect/coffee.vim
@@ -5,3 +5,4 @@
 
 autocmd BufNewFile,BufRead *.coffee set filetype=coffee
 autocmd BufNewFile,BufRead *Cakefile set filetype=coffee
+autocmd BufNewFile,BufRead *.coffeekup set filetype=coffee


### PR DESCRIPTION
When using coffeekup with express, the extension for the templates is `coffeekup`.
