### PR TITLE
set expandtab

### DIFF
--- a/indent/coffee.vim
+++ b/indent/coffee.vim
@@ -7,6 +7,9 @@ if exists("b:did_indent")
   finish
 endif
 
+" addition by Jon: expand tabs to spaces to fix the occasional INDENT problems
+setlocal expandtab
+
 let b:did_indent = 1
 
 setlocal autoindent


### PR DESCRIPTION
I was having a bunch of INDENT error when running my coffee scripts made in gvim, but adding 'set expandtab' to indent/coffee.vim fixed my problems. Have there been similar issues? Feel free to pull.
