### PR TITLE
Minor adjustment to indentation

### DIFF
--- a/indent/coffee.vim
+++ b/indent/coffee.vim
@@ -333,8 +333,12 @@ function! s:GetCoffeeIndent(curlinenum)
     endif
   endif
 
-  " Keep the current indent.
-  return -1
+  " If no indent / outdent is needed, keep the indentation level of the previous line if possible
+  if previndent
+    return previndent
+  else
+    return -1
+  endif
 endfunction
 
 " Wrap s:GetCoffeeIndent to keep the cursor position.


### PR DESCRIPTION
Before, if GetCoffeeIndent didn't detect the need to indent / outdent,
it would return -1. Now it returns the indentation level of the previous
line if it exists. This makes for more convenient behavior when typing
'cc' on an empty line below an indented line, and matches how other
vim extensions such as javascript behave.
