### PR TITLE
Allow use of :coffee in haml files for syntax highlighting

### DIFF
--- a/after/syntax/haml.vim
+++ b/after/syntax/haml.vim
@@ -6,4 +6,4 @@
 " Inherit coffee from html so coffeeComment isn't redefined and given higher
 " priority than hamlInterpolation.
 syn cluster hamlCoffeescript contains=@htmlCoffeeScript
-syn region  hamlCoffeescriptFilter matchgroup=hamlFilter start="^\z(\s*\):coffeescript\s*$" end="^\%(\z1 \| *$\)\@!" contains=@hamlCoffeeScript,hamlInterpolation keepend
+syn region  hamlCoffeescriptFilter matchgroup=hamlFilter start="^\z(\s*\):coffee\z(script\)*\s*$" end="^\%(\z1 \| *$\)\@!" contains=@hamlCoffeeScript,hamlInterpolation keepend


### PR DESCRIPTION
Some gems, like coffee-filter, denote coffeescript in a file with :coffee. It would be nice if we could have coffeescript syntax highlighting when we use :coffee and :coffeescript.

Just a slight modification to the regex in after/haml.vim
