### PR TITLE
Don't generate a js file when issuing :make

### DIFF
--- a/compiler/coffee.vim
+++ b/compiler/coffee.vim
@@ -19,7 +19,7 @@ endif
 " Get a `makeprg` for the current filename. This is needed to support filenames
 " with spaces and quotes, but also not break generic `make`.
 function! s:GetMakePrg()
-  return 'coffee -c ' . g:coffee_make_options . ' $* ' . fnameescape(expand('%'))
+  return 'coffee -p ' . g:coffee_make_options . ' $* ' . fnameescape(expand('%'))
 endfunction
 
 " Set `makeprg` and return 1 if coffee is still the compiler, else return 0.


### PR DESCRIPTION
When using `:make`, a javascript file is generated in the same directory as the coffee file. For example, `:make` on a file named `test.coffee` would generate `test.js`. This is _very_ undesired in certain cases, since this file would be `require`d instead of the coffee one, even if the latter had changed in the meantime.

This pull request simply uses the `-p` flag to print the javascript to stdout. This generates some noise in the console. Personally, I think that's preferable by far, but there are two other ways to deal with this that I can think of:
- Use `-o` to set the output directory for the compiled scripts to a temporary one. I'd rather
  not do this, since I don't feel it makes much sense to create a tempdir that won't ever be
  used just for that.
- Use `-p`, but redirect stdout to `/dev/null`. That would only work for *nix, though, and I
  can't really test on Windows.

The `-p` flag could be added to `coffee_make_options` on my own installation, of course, but the default behaviour was a big surprise to me, so I think it's better to put it directly in the invocation to avoid future issues.
