### PR TITLE
On pressing backspace+Enter, keep cursor indent

### DIFF
--- a/indent/coffee.vim
+++ b/indent/coffee.vim
@@ -241,6 +241,11 @@ function! GetCoffeeIndent(curlinenum)
     return -1
   endif
 
+  " If continuing a comment, keep the indent level.
+  if s:IsCommentLine(prevlinenum)
+    return -1
+  endif
+
   " Indent based on the current line.
   let curline = s:GetTrimmedLine(a:curlinenum)
 


### PR DESCRIPTION
When I want to "exit" a block of code while writing it, I press `<backspace>`. For example, I'm writing this:

``` coffee
if foo
  bar
  # cursor
```

When I press backspace, I'll get something like this:

``` coffee
if foo
  bar
# cursor
```

But then, I want to leave some space after the block, so I hit `<enter>`. The result is that the indent of the new line is set to the one of the last non-blank line:

``` coffee
if foo
  bar

  # cursor
```

While this seems to be a minor issue, it trips me up all the time. I suppose I should get used to leaving the space _first_ with an `<enter>`, but I can't seem to do so :). In python, the behaviour is exactly as I want it to be, so I took a cue from that indent file and I tweaked this one to work like that.

I understand there may be some specific reason to have it this way. If so, I have no complaints to rejecting this PR outright.
