### PR TITLE
Added Function Highlighting

### DIFF
--- a/syntax/coffee.vim
+++ b/syntax/coffee.vim
@@ -117,7 +117,8 @@ endif
 syn match coffeeObjAssign /@\?\I\i*\s*\ze::\@!/ contains=@coffeeIdentifier display
 hi def link coffeeObjAssign Identifier
 
-syn match coffeeFunction /\w\+\(\s*=.*\->\)\@=/ contains=@coffeeIdentifier display
+syn match coffeeFunction /@\?\I.*\w\+\ze\s*=\s*.*\->/ contains=@coffeeIdentifier display
+"syn match coffeeFunction /.*\w\+\ze\s*=\s*\((.*\->|\->\)/ contains=@coffeeIdentifier display
 hi def link coffeeFunction Function
 
 syn keyword coffeeTodo TODO FIXME XXX contained


### PR DESCRIPTION
It was really hard to read files written in a function style:

```
 one = ->
 two = (asdf) ->
```

since everything was the default coloring, you couldn't really see the function definitions. Feel free to clean it up, but I think it at least gives the idea. 
