### PR TITLE
Get the previous line's indentation in an empty line

### DIFF
--- a/indent/coffee.vim
+++ b/indent/coffee.vim
@@ -333,6 +333,16 @@ function! s:GetCoffeeIndent(curlinenum)
     endif
   endif
 
+  " If this line is empty, search backwards and return the indent of the
+  " previous line that received an explicit number from GetCoffeeIndent()
+  if getline(a:curlinenum) == ''
+    let x = a:curlinenum - 1
+    while x >= 0 && s:GetCoffeeIndent(x) == -1
+      let x -= 1
+    endwhile
+    return s:GetCoffeeIndent(x) - 1
+  endif
+
   " Keep the current indent.
   return -1
 endfunction


### PR DESCRIPTION
Fixes indenting a blank line to not start at column 0 but instead use
the previous line's indentation.

This case happens often when going from normal mode to insert mode with
`S` or deleting the current line with `cc`.

Hat tip to @osse for the [original implementation](https://gist.github.com/3947612).
