### PR TITLE
Emphasize `coffeeInterpDelim` for more distinction from `String`

### DIFF
--- a/syntax/coffee.vim
+++ b/syntax/coffee.vim
@@ -141,8 +141,6 @@ hi def link coffeeEmbedDelim Delimiter
 syn region coffeeInterp matchgroup=coffeeInterpDelim start=/#{/ end=/}/ contained
 \                       contains=@coffeeAll
 hi def link coffeeInterpDelim Operator
-" TODO
-" hi def coffeeInterpDelim term=underline cterm=underline gui=underline
 
 " A string escape sequence
 syn match coffeeEscape /\\\d\d\d\|\\x\x\{2\}\|\\u\x\{4\}\|\\./ contained display


### PR DESCRIPTION
link `coffeeInterpDelim` to `Operator` instead of `PreProc`. In this way it's more likely to be colored differently from `String` in a variety of color schemes.

Edit: Rationale: `"abc #{ expr } def"` is just `'abc' + expr + 'def'`, so`#{` and `}` are actually `"+` and `+"`, which look like operators to me. Normally `String` and `Operator` are contrasted, since string concatenation is frequent. 
