### PR TITLE
Unicode mathematical notation using `conceal`

### DIFF
--- a/after/syntax/coffee.vim
+++ b/after/syntax/coffee.vim
@@ -1,0 +1,35 @@
+if !exists('coffee_cute')
+  let coffee_cute = 0
+endif
+
+if !has('conceal') || !g:coffee_cute
+    finish
+endif
+
+syntax match coffeeNiceOperator "\<in\>" conceal cchar=∈
+syntax match coffeeNiceOperator "\<or\>" conceal cchar=∨
+syntax match coffeeNiceOperator "\<and\>" conceal cchar=∧
+" include the space after “not” – if present – so that “not a” becomes “¬a”.
+" also, don't hide “not” behind ‘¬’ if it is after “is ”.
+syntax match coffeeNiceOperator "\%(is \)\@<!\<not\%( \|\>\)" conceal cchar=¬
+syntax match coffeeNiceOperator "\<not in\>" conceal cchar=∉
+syntax match coffeeNiceOperator "<=" conceal cchar=≤
+syntax match coffeeNiceOperator ">=" conceal cchar=≥
+syntax match coffeeNiceOperator "!=" conceal cchar=≢
+syntax match coffeeNiceOperator "\<isnt\>" conceal cchar=≢
+" syntax match coffeeNiceOperator "\<is not\>" conceal cchar=≢
+" only conceal “==” if alone, to avoid concealing SCM conflict markers
+syntax match coffeeNiceOperator "=\@<!===\@!" conceal cchar=≡
+" only conceal "is" if it isn't followed by "not"
+syntax match coffeeNiceOperator "\<is\>\%( not\)\@!" conceal cchar=≡
+
+syntax match coffeeNiceOperator "\<\%(Math\.\)\?sqrt\>" conceal cchar=√
+syntax match coffeeNiceKeyword "\<\%(Math\.\)\?PI\>" conceal cchar=π
+
+syntax match coffeeNiceOperator "->" conceal cchar=→
+syntax match coffeeNiceOperator "=>" conceal cchar=⇒
+
+hi link coffeeNiceOperator Operator
+hi! link Conceal Operator
+
+setlocal conceallevel=1

--- a/doc/coffee-script.txt
+++ b/doc/coffee-script.txt
@@ -94,6 +94,13 @@ Set default options |CoffeeLint| should pass to {coffeelint}.
 >
 	let coffee_lint_options = '-f lint.json'
 <
+						*g:coffee_cute*
+Replaces various keywords with UTF-8 symbols. For instance, "is not" becomes
+"≢", "and" becomes "∧" and "or" becomes "∨", et cetera. Disabled by default,
+can be enabled with:
+>
+	let coffee_cute = 1
+<
 
 Syntax Highlighting~
 						*ft-coffee-script-syntax*


### PR DESCRIPTION
Inspired by (and based on) [vim-cute-python](https://github.com/ehamberg/vim-cute-python).

After enabling `g:coffee_cute`, certain keywords are replaced with their equivalent mathematical notation (such as ∈, ∧ and ∨) and function arrows are converted to unicode as well.

CoffeeScript is pretty terse already, so I doubt anyone will use this, but it's a nice showcase of `conceal`, don't you think?
