### PR TITLE
Don't modify loop control variable when looking for comments.

### DIFF
--- a/indent/coffee.vim
+++ b/indent/coffee.vim
@@ -208,15 +208,17 @@ function! s:FindComment(linenum)
 
   while cur != end
     call cursor(0, cur + 1)
-    let [_, cur] = searchpos('#', 'cn', a:linenum)
+    let [_, column] = searchpos('#', 'cn', a:linenum)
 
-    if !cur
+    if !column
       break
     endif
 
-    if s:IsComment(a:linenum, cur)
-      return cur
+    if s:IsComment(a:linenum, column)
+      return column
     endif
+
+    let cur = cur + 1
   endwhile
 
   return 0


### PR DESCRIPTION
Fixes #119 & #120, thanks to @doits, @kikyous and @xqin for initial reports.

The assignment [_, cur] = searchpos(...) modifies cur variable and does not increment it
if no result is found.
Use different variable name for searchpos return value and increase cur
at the end of loop.

Since this is my first time writing VimL please review this thoroughly - I'm pretty sure this is not the perfect solution.
Also I have no idea why this started occurring now - the plugin hasn't been changed recently. Might this be due to change in Vim itself somehow?
