### PR TITLE
Simple support for literate coffeescript

### DIFF
--- a/ftdetect/coffee.vim
+++ b/ftdetect/coffee.vim
@@ -7,6 +7,7 @@ autocmd BufNewFile,BufRead *.coffee set filetype=coffee
 autocmd BufNewFile,BufRead *Cakefile set filetype=coffee
 autocmd BufNewFile,BufRead *.coffeekup,*.ck set filetype=coffee
 autocmd BufNewFile,BufRead *._coffee set filetype=coffee
+autocmd BufNewFile,BufRead *.litcoffee set filetype=litcoffee
 
 function! s:DetectCoffee()
     if getline(1) =~ '^#!.*\<coffee\>'

--- a/syntax/litcoffee.vim
+++ b/syntax/litcoffee.vim
@@ -1,0 +1,26 @@
+" Language:    CoffeeScript
+" Maintainer:  Mick Koch <kchmck@gmail.com>
+" URL:         http://github.com/kchmck/vim-coffee-script
+" License:     WTFPL
+
+" Bail if our syntax is already loaded.
+if exists('b:current_syntax') && b:current_syntax == 'litcoffee'
+  finish
+endif
+
+" Use markdown syntax as basis
+runtime syntax/markdown.vim
+unlet b:current_syntax
+
+" Include coffee syntax as a group
+syn include @coffee syntax/coffee.vim
+
+" Region definition taken from markdown.vim
+syn region markdownCodeBlock start="    \|\t" end="$" contained contains=@coffee,coffeeObject
+
+" Fix for wrong coffeeObject highlighting. Not sure why it's needed
+syn match coffeeObject /\<\u\w*\>/ display contained
+
+if !exists('b:current_syntax')
+  let b:current_syntax = 'litcoffee'
+endif


### PR DESCRIPTION
Apparently, coffeescript comes with a literate variant -- http://coffeescript.org/#literate. This pull request implements simple syntax highlighting for it by using the markdown syntax and then including coffee syntax in it. I think there are some mismatches, but regrettably, I don't understand syntax highlighting a lot, so I'm not sure how to fix them. I may update the code if I figure it out.
