### PR TITLE
Add support for coffee-script 1.6 error format

### DIFF
--- a/compiler/coffee.vim
+++ b/compiler/coffee.vim
@@ -56,6 +56,7 @@ call s:SetMakePrg()
 CompilerSet errorformat=Error:\ In\ %f\\,\ %m\ on\ line\ %l,
                        \Error:\ In\ %f\\,\ Parse\ error\ on\ line\ %l:\ %m,
                        \SyntaxError:\ In\ %f\\,\ %m,
+                       \%f:%l:\ error:\ %m,
                        \%-G%.%#
 
 " Compile the current file.


### PR DESCRIPTION
coffee-script 1.6 changes the error output format. An error that would look like the following under coffee-script 1.4:

```
SyntaxError: In lib/www_routes.coffee, unmatched ) on line 53
    at SyntaxError (unknown source)
    at Lexer.exports.Lexer.Lexer.error (/usr/local/lib/node_modules/coffee-script/lib/coffee-script/lexer.js:682:13)
    at Lexer.exports.Lexer.Lexer.pair (/usr/local/lib/node_modules/coffee-script/lib/coffee-script/lexer.js:634:16)
    at Lexer.exports.Lexer.Lexer.pair (/usr/local/lib/node_modules/coffee-script/lib/coffee-script/lexer.js:638:21)
    at Lexer.exports.Lexer.Lexer.pair (/usr/local/lib/node_modules/coffee-script/lib/coffee-script/lexer.js:638:21)
    at Lexer.exports.Lexer.Lexer.literalToken (/usr/local/lib/node_modules/coffee-script/lib/coffee-script/lexer.js:456:16)
    at Lexer.exports.Lexer.Lexer.tokenize (/usr/local/lib/node_modules/coffee-script/lib/coffee-script/lexer.js:33:220)
    at Object.exports.compile.compile (/usr/local/lib/node_modules/coffee-script/lib/coffee-script/coffee-script.js:47:32)
    at compileScript (/usr/local/lib/node_modules/coffee-script/lib/coffee-script/command.js:182:33)
    at fs.stat.notSources.(anonymous function) (/usr/local/lib/node_modules/coffee-script/lib/coffee-script/command.js:152:18)
```

now looks like this under 1.6:

```
lib/www_routes.coffee:53:9: error: unmatched )
        ), done
    ^
```

resulting in CoffeeMake not properly parsing the error for display in quickfix windows and such.

This commit adds the syntax line for 1.6 to support parsing the new format.
