### PR TITLE
Let b:current_syntax correct

### DIFF
--- a/syntax/coffee.vim
+++ b/syntax/coffee.vim
@@ -10,6 +10,9 @@ endif
 
 " Include JavaScript for coffeeEmbed.
 syn include @coffeeJS syntax/javascript.vim
+if exists('b:current_syntax')
+  unlet b:current_syntax
+endif
 
 " Highlight long strings.
 syn sync minlines=100


### PR DESCRIPTION
`b:current_syntax` is 'javascript' now, should unlet after source `syntax/javascript.vim` to make it become 'coffee'.
