### PR TITLE
Add function and method definition syntax highlighting

### DIFF
--- a/syntax/coffee.vim
+++ b/syntax/coffee.vim
@@ -42,7 +42,7 @@ hi def link coffeeKeyword Keyword
 
 " syn match coffeeFunction  /\s\?[-=]>/
 syn match coffeeFunction /@\?\I.*\w\+\ze\s*=\s*.*[-=]>/ contains=@coffeeIdentifier display
-hi def link coffeefunction Identifier
+hi def link coffeefunction Function
 
 syn keyword coffeeOperator  instanceof typeof delete length
 \                       display


### PR DESCRIPTION
This adds `coffeeFunction` and `coffeeMethod` syntax elements which are linked to
`coffeeStatement` and `coffeeObjAssign`, respectively. This ensures that existing
themes will continue to behave as they have, but makes it possible to highlight
functions and methods separately à la Sublime Text. For instance one might want to use their theme's function and method highlight colors:

``` viml
hi link coffeeFunction Function
hi link coffeeMethod Method
```

Syntax highlighting similar to Sublime Text is achievable with the following:

``` viml
hi link coffeeFunction Function
hi link coffeeMethod Function
hi link coffeeObjAssign Statement
```

Based on the efforts of @seanhess, and addressing the issue raised by @bergman with #102 (function calls incorrectly being captured).
