### PR TITLE
Only unlet b:did_indent when it is set.

### DIFF
--- a/after/indent/html.vim
+++ b/after/indent/html.vim
@@ -4,12 +4,16 @@
 " License:     WTFPL
 
 " Load the coffee and html indent functions.
-unlet b:did_indent
+if exists('b:did_indent')
+  unlet b:did_indent
+endif
 runtime indent/coffee.vim
 let s:coffeeIndentExpr = &l:indentexpr
 
 " Load html last so it can overwrite coffee settings.
-unlet b:did_indent
+if exists('b:did_indent')
+  unlet b:did_indent
+endif
 runtime indent/html.vim
 let s:htmlIndentExpr = &l:indentexpr
 


### PR DESCRIPTION
This resolves the vim startup error I'm receiving after updating this plugin:

```
Error detected while processing ~/.vim/bundle/vim-coffee-script/after/indent/html.vim:
line    7:
E108: No such variable: "b:did_indent"
```
