### PR TITLE
Update makeprg on BufWritePre

### DIFF
--- a/compiler/coffee.vim
+++ b/compiler/coffee.vim
@@ -75,8 +75,8 @@ augroup CoffeeUpdateMakePrg
 
   " Set autocmd locally if compiler was set locally.
   if &l:makeprg =~ s:pat
-    autocmd BufFilePost,BufWritePost <buffer> call s:UpdateMakePrg()
+    autocmd BufWritePre,BufFilePost,BufWritePost <buffer> call s:UpdateMakePrg()
   else
-    autocmd BufFilePost,BufWritePost          call s:UpdateMakePrg()
+    autocmd BufWritePre,BufFilePost,BufWritePost          call s:UpdateMakePrg()
   endif
 augroup END


### PR DESCRIPTION
Since we suggest user auto compile on BufWritePost, it's a good idea to update compile options before compile.
