### PR TITLE
README: adapt to Vundle interface change

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -91,7 +91,7 @@ Updating takes two steps:
    set rtp+=~/.vim/bundle/vundle/
    call vundle#rc()
 
-   Bundle 'kchmck/vim-coffee-script'
+   Plugin 'kchmck/vim-coffee-script'
 
    syntax enable
    filetype plugin indent on
@@ -100,9 +100,9 @@ Updating takes two steps:
    If you're adding Vundle to a built-up vimrc, just make sure all these calls
    are in there and that they occur in this order.
 
-3. Open vim and run `:BundleInstall`.
+3. Open vim and run `:PluginInstall`.
 
-To update, open vim and run `:BundleInstall!` (notice the bang!)
+To update, open vim and run `:PluginInstall!` (notice the bang!)
 
 ## Install from a Zip File
 


### PR DESCRIPTION
"Bundle" is now "Plugin"

https://github.com/gmarik/Vundle.vim/blob/master/doc/vundle.txt#L345-L369
