### PR TITLE
reduced possible exponential prefixes to just 'e'

### DIFF
--- a/syntax/coffee.vim
+++ b/syntax/coffee.vim
@@ -92,7 +92,7 @@ syn region coffeeString start=/'/ skip=/\\\\\|\\'/ end=/'/
 hi def link coffeeString String
 
 " A integer, including a leading plus or minus
-syn match coffeeNumber /\%(\i\|\$\)\@<![-+]\?\d\+\%([eE][+-]\?\d\+\)\?/ display
+syn match coffeeNumber /\%(\i\|\$\)\@<![-+]\?\d\+\%(e[+-]\?\d\+\)\?/ display
 " A hex, binary, or octal number
 syn match coffeeNumber /\<0[xX]\x\+\>/ display
 syn match coffeeNumber /\<0[bB][01]\+\>/ display


### PR DESCRIPTION
Coffeescript exponential numbers can only be prefixed with a lower-case `e`; upper case `E` does not work:

> [stdin]:8:67: error: exponential notation in '9E50' must be indicated with a lowercase 'e'