### PR TITLE
Fixes the suffixesadd value

### DIFF
--- a/ftplugin/coffee.vim
+++ b/ftplugin/coffee.vim
@@ -13,7 +13,7 @@ call coffee#CoffeeSetUpVariables()
 setlocal formatoptions-=t formatoptions+=croql
 setlocal comments=:# commentstring=#\ %s
 setlocal omnifunc=javascriptcomplete#CompleteJS
-setlocal suffixesadd+=coffee
+setlocal suffixesadd+=.coffee
 
 " Create custom augroups.
 augroup CoffeeBufUpdate | augroup END


### PR DESCRIPTION
The suffixesadd value must contain the dot before its extension name.
The example found in the help is with .java, see :h suffixesadd