### PR TITLE
Preserve b:current_syntax while loading syntax as subtype

### DIFF
--- a/after/syntax/haml.vim
+++ b/after/syntax/haml.vim
@@ -3,6 +3,11 @@
 " URL:         http://github.com/kchmck/vim-coffee-script
 " License:     WTFPL
 
+
+if exists('b:current_syntax')
+  let s:current_syntax_save = b:current_syntax
+endif
+
 " Inherit coffee from html so coffeeComment isn't redefined and given higher
 " priority than hamlInterpolation.
 syn cluster hamlCoffeescript contains=@htmlCoffeeScript
@@ -11,3 +16,8 @@ syn region  hamlCoffeescriptFilter matchgroup=hamlFilter
 \                                  end="^\%(\z1 \| *$\)\@!"
 \                                  contains=@hamlCoffeeScript,hamlInterpolation
 \                                  keepend
+
+if exists('s:current_syntax_save')
+  let b:current_syntax = s:current_syntax_save
+  unlet s:current_syntax_save
+endif

--- a/after/syntax/html.vim
+++ b/after/syntax/html.vim
@@ -3,9 +3,18 @@
 " URL:         http://github.com/kchmck/vim-coffee-script
 " License:     WTFPL
 
+if exists('b:current_syntax')
+  let s:current_syntax_save = b:current_syntax
+endif
+
 " Syntax highlighting for text/coffeescript script tags
 syn include @htmlCoffeeScript syntax/coffee.vim
 syn region coffeeScript start=#<script [^>]*type="text/coffeescript"[^>]*>#
 \                       end=#</script>#me=s-1 keepend
 \                       contains=@htmlCoffeeScript,htmlScriptTag,@htmlPreproc
 \                       containedin=htmlHead
+
+if exists('s:current_syntax_save')
+  let b:current_syntax = s:current_syntax_save
+  unlet s:current_syntax_save
+endif


### PR DESCRIPTION
This pull request fixes errors tied with plugins, working with b:current_syntax variable (e.g. [javascript-libraries-syntax](https://github.com/othree/javascript-libraries-syntax.vim), which provies extra syntax used in completion, visual detemination of typos etc.)

Before the pull request:
Within a file with &ft == 'html', b:current_syntax will be equal to 'coffee' (which is 
absurdly semantically and, in addition, it disrupts sourcing of other html syntax files with b:current_syntax == 'html' check.

After: 
Within the file with &ft == 'html', b:current_syntax will be equal to 'html' (as expected). 