### PR TITLE
html tag attribute values may also be un- or singlequoted.

### DIFF
--- a/after/indent/html.vim
+++ b/after/indent/html.vim
@@ -18,7 +18,7 @@ setlocal indentexpr=GetCoffeeHtmlIndent(v:lnum)
 
 function! GetCoffeeHtmlIndent(curlinenum)
   " See if we're inside a coffeescript block.
-  let scriptlnum = searchpair('<script [^>]*type="text/coffeescript"[^>]*>', '',
+  let scriptlnum = searchpair('<script [^>]*type=[''"]\?text/coffeescript[''"]\?[^>]*>', '',
   \                           '</script>', 'bWn')
   let prevlnum = prevnonblank(a:curlinenum)
 

--- a/after/syntax/html.vim
+++ b/after/syntax/html.vim
@@ -9,7 +9,7 @@ endif
 
 " Syntax highlighting for text/coffeescript script tags
 syn include @htmlCoffeeScript syntax/coffee.vim
-syn region coffeeScript start=#<script [^>]*type="text/coffeescript"[^>]*>#
+syn region coffeeScript start=#<script [^>]*type=['"]\?text/coffeescript['"]\?[^>]*>#
 \                       end=#</script>#me=s-1 keepend
 \                       contains=@htmlCoffeeScript,htmlScriptTag,@htmlPreproc
 \                       containedin=htmlHead

--- a/test/test.html
+++ b/test/test.html
@@ -4,4 +4,14 @@
       def: 42
     }
   </script>
+  <script type='text/coffeescript'>
+    abc = {
+      def: 42
+    }
+  </script>
+  <script type=text/coffeescript>
+    abc = {
+      def: 42
+    }
+  </script>
 </head>


### PR DESCRIPTION
The html standard
[allows](http://www.w3.org/TR/html-markup/syntax.html#attribute)
unquoted, single-quoted and double-quoted attribute values, this
patch accepts all three behaviours.