### PR TITLE
Use CoffeeScript filetype for *.cson files

### DIFF
--- a/ftdetect/coffee.vim
+++ b/ftdetect/coffee.vim
@@ -7,6 +7,7 @@ autocmd BufNewFile,BufRead *.coffee set filetype=coffee
 autocmd BufNewFile,BufRead *Cakefile set filetype=coffee
 autocmd BufNewFile,BufRead *.coffeekup,*.ck set filetype=coffee
 autocmd BufNewFile,BufRead *._coffee set filetype=coffee
+autocmd BufNewFile,BufRead *.cson set filetype=coffee
 
 function! s:DetectCoffee()
     if getline(1) =~ '^#!.*\<coffee\>'


### PR DESCRIPTION
For reference, the CoffeeScript packages for [Atom](https://github.com/atom/language-coffee-script/blob/b76b47f7d3fc04c90303af7920af034272fe8e8f/grammars/coffeescript.cson#L7) and [Sublime Text](https://github.com/aponxi/sublime-better-coffeescript/blob/0b65011a96a474ccc255612a5202d43525822556/CoffeeScript.tmLanguage#L12) also apply for CSON files.